### PR TITLE
feat(FormlyField): use `ng-container` instead of deprecated `template`.

### DIFF
--- a/demo/horizontal.wrapper.ts
+++ b/demo/horizontal.wrapper.ts
@@ -6,7 +6,7 @@ import { FieldWrapper } from '../src/core/templates/field.wrapper';
     <div class="row">
       <label attr.for="{{key}}" class="col-sm-4 form-control-label">{{to.label}}</label>
       <div class="col-sm-8">
-        <template #fieldComponent></template>
+        <ng-container #fieldComponent></ng-container>
       </div>
     </div>
   `,

--- a/demo/panel.wrapper.ts
+++ b/demo/panel.wrapper.ts
@@ -6,7 +6,7 @@ import { FieldWrapper } from '../src/core/templates/field.wrapper';
     <div class="card">
       <h3 class="card-header">{{to.title}}</h3>
       <div class="card-block">
-        <template #fieldComponent></template>
+        <ng-container #fieldComponent></ng-container>
       </div>
     </div>
   `,

--- a/src/core/components/formly.field.spec.ts
+++ b/src/core/components/formly.field.spec.ts
@@ -326,7 +326,7 @@ export class FormlyFieldText extends FieldType {}
   selector: 'formly-wrapper-label',
   template: `
     <label [attr.for]="id">{{to.label}}</label>
-    <template #fieldComponent></template>
+    <ng-container #fieldComponent></ng-container>
   `,
 })
 export class FormlyWrapperLabel extends FieldWrapper {

--- a/src/core/components/formly.field.ts
+++ b/src/core/components/formly.field.ts
@@ -14,7 +14,7 @@ import { map } from 'rxjs/operator/map';
 @Component({
   selector: 'formly-field',
   template: `
-    <template #fieldComponent></template>
+    <ng-container #fieldComponent></ng-container>
     <div *ngIf="field.template && !field.fieldGroup" [innerHtml]="field.template"></div>
   `,
 })

--- a/src/ui-bootstrap/types/select.ts
+++ b/src/ui-bootstrap/types/select.ts
@@ -19,14 +19,14 @@ export class SelectOption {
   template: `
     <select [formControl]="formControl" class="form-control" [formlyAttributes]="field">
       <option value="" *ngIf="to.placeholder">{{to.placeholder}}</option>
-      <template ngFor let-item [ngForOf]="selectOptions">
+      <ng-container *ngFor="let item of selectOptions">
        <optgroup *ngIf="item.group" label="{{item.label}}">
          <option *ngFor="let child of item.group" [value]="child.value">
            {{child.label}}
          </option>
        </optgroup>
        <option *ngIf="!item.group" [value]="item.value">{{item.label}}</option>
-    </template>
+      </ng-container>
     </select>
   `,
 })

--- a/src/ui-bootstrap/wrappers/addons.ts
+++ b/src/ui-bootstrap/wrappers/addons.ts
@@ -12,7 +12,7 @@ import { FieldWrapper } from '../../core/core';
         <i [ngClass]="to.addonLeft.class" *ngIf="to.addonLeft.class"></i>
         <span *ngIf="to.addonLeft.text">{{to.addonLeft.text}}</span>
     </div>
-    <template #fieldComponent></template>
+    <ng-container #fieldComponent></ng-container>
     <div class="input-group-addon"
          *ngIf="to.addonRight"
          [ngStyle]="{cursor: to.addonRight.onClick ? 'pointer' : 'inherit'}"

--- a/src/ui-bootstrap/wrappers/description.ts
+++ b/src/ui-bootstrap/wrappers/description.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '../../core/core';
 @Component({
   selector: 'formly-wrapper-description',
   template: `
-    <template #fieldComponent></template>
+    <ng-container #fieldComponent></ng-container>
     <div>
       <small class="text-muted">{{to.description}}</small>
     </div>

--- a/src/ui-bootstrap/wrappers/fieldset.ts
+++ b/src/ui-bootstrap/wrappers/fieldset.ts
@@ -5,7 +5,7 @@ import { FieldWrapper } from '../../core/core';
   selector: 'formly-wrapper-fieldset',
   template: `
     <div class="form-group" [ngClass]="{'has-danger': valid}">
-      <template #fieldComponent></template>
+      <ng-container #fieldComponent></ng-container>
     </div>
   `,
 })

--- a/src/ui-bootstrap/wrappers/label.ts
+++ b/src/ui-bootstrap/wrappers/label.ts
@@ -5,7 +5,7 @@ import { FieldWrapper } from '../../core/core';
   selector: 'formly-wrapper-label',
   template: `
     <label [attr.for]="id" class="form-control-label">{{to.label}}</label>
-    <template #fieldComponent></template>
+    <ng-container #fieldComponent></ng-container>
   `,
 })
 export class FormlyWrapperLabel extends FieldWrapper {

--- a/src/ui-bootstrap/wrappers/message-validation.ts
+++ b/src/ui-bootstrap/wrappers/message-validation.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '../../core/core';
 @Component({
   selector: 'formly-wrapper-validation-messages',
   template: `
-    <template #fieldComponent></template>
+    <ng-container #fieldComponent></ng-container>
     <div>
       <small class="text-muted text-danger" *ngIf="valid" role="alert" [id]="validationId"><formly-validation-message [fieldForm]="formControl" [field]="field"></formly-validation-message></small>
     </div>


### PR DESCRIPTION
**What kind of change does this PR introduce? feature**

in angular v4 `template` is deprecated in favor of `ng-template` and there is no way to change it without breaking change. Replacing it with `ng-container` would allow us to support both v2 and v4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/383)
<!-- Reviewable:end -->
