### PR TITLE
fix(utils): deal with readonly properties on reverseDeepMerge (#408)

### DIFF
--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -1,6 +1,16 @@
 import { reverseDeepMerge, assignModelValue, getFieldId, getValueForKey, getKey, evalExpression, getKeyPath, getFieldModel } from './utils';
 import { FormlyFieldConfig } from './components/formly.field.config';
 
+class FooBar {
+
+  foo = 'foo';
+  bar = 'bar';
+
+  get foobar(): string {
+    return '';
+  }
+}
+
 describe('FormlyUtils service', () => {
   describe('reverseDeepMerge', () => {
     it('should properly reverse deep merge', () => {
@@ -11,6 +21,18 @@ describe('FormlyUtils service', () => {
       expect(foo['foo']).toEqual('bar');
       expect(foo['foobar']).toEqual('foobar');
     });
+
+    it('should properly reverse deep merge even with readonly attributes', () => {
+      let foo = new FooBar();
+      let bar = new FooBar();
+      foo.foo = 'bar';
+
+      reverseDeepMerge(foo, bar);
+
+      expect(foo['foo']).toEqual('bar');
+      expect(foo['foobar']).toEqual('');
+    });
+
   });
 
   describe('assignModelValue', () => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -113,7 +113,13 @@ export function reverseDeepMerge(dest, source = undefined) {
         if (isFunction(src[srcArg])) {
           dest[srcArg] = src[srcArg];
         } else {
-          dest[srcArg] = clone(src[srcArg]);
+          try {
+            dest[srcArg] = clone(src[srcArg]);
+          }  catch (e) {
+            if (e instanceof TypeError) {
+              // Setting a readonly attribute
+            }
+          }
         }
       } else if (objAndSameType(dest[srcArg], src[srcArg])) {
         reverseDeepMerge(dest[srcArg], src[srcArg]);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix for issue #408 

**What is the current behavior? (You can also link to an open issue here)**
reverseDeepMerge throws an exception when a property on dest is readonly, empty or null.


**What is the new behavior (if this is a feature change)?**
when the model contains a readonly property and the default dest is empty, reverseDeepMerge will
catch the exception and proceed with the merge


**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/409)
<!-- Reviewable:end -->
