### PR TITLE
fix(FormlyForm): allow className even if fieldGroup is set

### DIFF
--- a/demo/src/app.component.ts
+++ b/demo/src/app.component.ts
@@ -59,7 +59,7 @@ export class AppComponent {
           description: 'Select a title that suits your description',
         },
       }, {
-        className: 'row',
+        fieldGroupClassName: 'row',
         fieldGroup: [{
           className: 'col-md-6',
           key: 'email',
@@ -177,7 +177,7 @@ export class AppComponent {
         template: '<hr/><div><strong>Address:</strong></div>',
       }, {
         key: 'address',
-        className: 'row',
+        fieldGroupClassName: 'row',
         wrappers: ['panel'],
         templateOptions: {
           title: 'Address',
@@ -367,7 +367,7 @@ export class AppComponent {
         type: 'repeatSection',
         key: 'investments',
         fieldArray: {
-          className: 'row',
+          fieldGroupClassName: 'row',
           templateOptions: {
             btnText: 'Add another investment',
           },

--- a/demo/src/formly/types/repeatedSection.ts
+++ b/demo/src/formly/types/repeatedSection.ts
@@ -11,7 +11,7 @@ import { FieldType, FormlyFormBuilder } from 'ng-formly/core';
         [fields]="fields(i)"
         [options]="newOptions"
         [form]="this.formControl.at(i)"
-        [ngClass]="field.fieldArray.className">
+        [ngClass]="field.fieldArray.fieldGroupClassName">
       </formly-form>
       <div class="col-md-2">
         <button class="btn btn-danger" (click)="remove(i)">Remove</button>

--- a/src/core/components/formly.field.config.ts
+++ b/src/core/components/formly.field.config.ts
@@ -18,6 +18,7 @@ export interface FormlyFieldConfig {
   component?: any;
   wrapper?: string[] | string;
   wrappers?: string[];
+  fieldGroupClassName?: string;
   fieldGroup?: Array<FormlyFieldConfig>;
   fieldArray?: FormlyFieldConfig;
   hide?: boolean;

--- a/src/core/components/formly.form.ts
+++ b/src/core/components/formly.form.ts
@@ -11,7 +11,7 @@ import { assignModelValue, isNullOrUndefined, isObject, reverseDeepMerge, getKey
     <formly-field *ngFor="let field of fields"
       [model]="fieldModel(field)" [form]="form"
       [field]="field" (modelChange)="changeModel($event)"
-      [ngClass]="!field.fieldGroup ? field.className: undefined"
+      [ngClass]="field.className"
       [options]="options">
     </formly-field>
     <ng-content></ng-content>

--- a/src/core/components/formly.group.ts
+++ b/src/core/components/formly.group.ts
@@ -6,7 +6,7 @@ import { clone } from '../utils';
 @Component({
   selector: 'formly-group',
   template: `
-    <formly-form [fields]="field.fieldGroup" [model]="model" [form]="formlyGroup" [options]="newOptions" [ngClass]="field.className" [buildForm]="false"></formly-form>
+    <formly-form [fields]="field.fieldGroup" [model]="model" [form]="formlyGroup" [options]="newOptions" [ngClass]="field.fieldGroupClassName" [buildForm]="false"></formly-form>
   `,
 })
 export class FormlyGroup extends FieldType {


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix, feature**

I decided to keep the className for `FormlyForm` even if `fieldGroup` is present this will introduce a BC break but we don't have a choice:

- when using `className` it should refer to the root element `<formly-field>`
- in order to apply className for  `<formly-form>` when using `fieldGroup` you should define the class name in `fieldGroupClassName` option.

### Before
```ts
  className: 'row',
  fieldGroup: ...
```

### After
```ts
  fieldGroupClassName: 'row',
  fieldGroup: ...
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/442)
<!-- Reviewable:end -->
