### PR TITLE
fix(validation) allow null/empty and equal values in min/max validation

### DIFF
--- a/src/core/services/formly.form.builder.spec.ts
+++ b/src/core/services/formly.form.builder.spec.ts
@@ -271,7 +271,13 @@ describe('FormlyFormBuilder service', () => {
         { name: 'minLength', value: 5, valid: '12345', invalid: '123' },
         { name: 'maxLength', value: 10, valid: '123', invalid: '12345678910' },
         { name: 'min', value: 5, valid: 6, invalid: 3 },
+        { name: 'min', value: 10, valid: 10, invalid: 2 },
+        { name: 'min', value: 10, valid: null, invalid: 2 },
+        { name: 'min', value: 10, valid: '', invalid: 2 },
         { name: 'max', value: 10, valid: 8, invalid: 11 },
+        { name: 'max', value: 4, valid: 4, invalid: 5 },
+        { name: 'max', value: 4, valid: null, invalid: 5 },
+        { name: 'max', value: 4, valid: '', invalid: 5 },
       ];
 
       options.map(option => {

--- a/src/core/services/formly.form.builder.ts
+++ b/src/core/services/formly.form.builder.ts
@@ -283,10 +283,14 @@ export class FormlyFormBuilder {
   }
 
   private checkMinMax(opt, changes, value) {
+    if (changes == null || changes === '' ) {
+      return true;
+    }
+
     if (opt === this.validationOpts[4]) {
-        return parseInt(changes) > value;
+        return parseInt(changes) >= value;
     } else {
-        return parseInt(changes) < value;
+        return parseInt(changes) <= value;
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix


**What is the current behavior? (You can also link to an open issue here)**
Currently formly doesn't allow you to have optional fields with min/max. It also doesn't allow you to have equal values

**What is the new behavior (if this is a feature change)?**
The new behavior allows you to have optional fields and equal values

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/449)
<!-- Reviewable:end -->
