### PR TITLE
fix: replace deprecated OpaqueToken with InjectionToken

### DIFF
--- a/src/core/src/services/formly.config.ts
+++ b/src/core/src/services/formly.config.ts
@@ -1,10 +1,10 @@
-import { Injectable, Inject, OpaqueToken } from '@angular/core';
+import { Injectable, Inject, InjectionToken } from '@angular/core';
 import { FormlyGroup } from '../components/formly.group';
 import { Field } from './../templates/field';
 import { reverseDeepMerge } from './../utils';
 import { FormlyFieldConfig } from '../components/formly.field.config';
 
-export const FORMLY_CONFIG_TOKEN = new OpaqueToken('FORMLY_CONFIG_TOKEN');
+export const FORMLY_CONFIG_TOKEN = new InjectionToken<FormlyConfig>('FORMLY_CONFIG_TOKEN');
 
 /**
  * Maintains list of formly field directive types. This can be used to register new field templates.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix of deprecated function OpaqueToken see: https://github.com/angular/angular/blob/d169c2434e3b5cd5991e38ffd8904e0919f11788/modules/%40angular/core/src/di/injection_token.ts#L29


**What is the current behavior?**
Not working on angular 5 because of deprecated function


**What is the new behavior?**
Working on angular 5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/508)
<!-- Reviewable:end -->
