### PR TITLE
feat(field): deprecated valid in favor of showError.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-formly",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.13",
   "author": "Zama Khan Mohammed <mohammedzamakhan@gmail.com>",
   "contributors": [
     "Zama Khan Mohammed <mohammedzamakhan@gmail.com>",

--- a/src/core/src/templates/field.ts
+++ b/src/core/src/templates/field.ts
@@ -22,7 +22,16 @@ export abstract class Field {
 
   get to(): FormlyTemplateOptions { return this.field.templateOptions; }
 
-  get valid(): boolean { return this.options.showError(this); }
+  /**
+   * @deprecated Use `showError` instead.
+   **/
+  get valid(): boolean {
+    console.warn(`${this.constructor.name}: 'valid' is deprecated. Use 'showError' instead.`);
+
+    return this.showError;
+  }
+
+  get showError(): boolean { return this.options.showError(this); }
 
   get id(): string { return this.field.id; }
 

--- a/src/ui-bootstrap/src/types/input.ts
+++ b/src/ui-bootstrap/src/types/input.ts
@@ -5,7 +5,7 @@ import { FieldType } from '../../../core';
   selector: 'formly-field-input',
   template: `
     <input [type]="type" [formControl]="formControl" class="form-control"
-      [formlyAttributes]="field" [ngClass]="{'form-control-danger': valid}">
+      [formlyAttributes]="field" [ngClass]="{'form-control-danger': showError}">
     `,
 })
 export class FormlyFieldInput extends FieldType {

--- a/src/ui-bootstrap/src/wrappers/fieldset.ts
+++ b/src/ui-bootstrap/src/wrappers/fieldset.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '../../../core';
 @Component({
   selector: 'formly-wrapper-fieldset',
   template: `
-    <div class="form-group" [ngClass]="{'has-danger': valid}">
+    <div class="form-group" [ngClass]="{'has-danger': showError}">
       <ng-container #fieldComponent></ng-container>
     </div>
   `,

--- a/src/ui-bootstrap/src/wrappers/message-validation.ts
+++ b/src/ui-bootstrap/src/wrappers/message-validation.ts
@@ -6,7 +6,7 @@ import { FieldWrapper } from '../../../core';
   template: `
     <ng-container #fieldComponent></ng-container>
     <div>
-      <small class="text-muted text-danger" *ngIf="valid" role="alert" [id]="validationId"><formly-validation-message [fieldForm]="formControl" [field]="field"></formly-validation-message></small>
+      <small class="text-muted text-danger" *ngIf="showError" role="alert" [id]="validationId"><formly-validation-message [fieldForm]="formControl" [field]="field"></formly-validation-message></small>
     </div>
   `,
 })


### PR DESCRIPTION
**What kind of change does this PR introduce? Bug fix, feature**

**What is the current behavior?**

`valid` was wrongly implemented it get the opposite value of what we expected (if valid return **false**, if not valid return **true**)

**What is the new behavior (if this is a feature change)?**
`showError` will be used instead of `valid` (to be removed in `v2`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/532)
<!-- Reviewable:end -->
