### PR TITLE
fix(FormlyFormBuilder): address null reference when `validation.show`…

### DIFF
--- a/src/core/src/services/formly.form.builder.spec.ts
+++ b/src/core/src/services/formly.form.builder.spec.ts
@@ -156,6 +156,42 @@ describe('FormlyFormBuilder service', () => {
       expect(control).not.toBeNull();
       expect(control.value).toEqual('created by component');
     });
+
+    it('should add form control to form When `hide` is false', () => {
+      field = {
+        key: 'title',
+        type: 'input',
+        hideExpression: 'false',
+        validation: {
+          show: true,
+        },
+      };
+
+      builder.buildForm(form, [field], {}, {});
+      let control: FormControl = <FormControl> form.get('title');
+
+      expect(field.hide).toBeFalsy();
+      expect(field.formControl).not.toBeNull();
+      expect(control).not.toBeNull();
+    });
+
+    it('should not add form control to form when `hide` is true', () => {
+      field = {
+        key: 'title',
+        type: 'input',
+        hideExpression: 'true',
+        validation: {
+          show: true,
+        },
+      };
+
+      builder.buildForm(form, [field], {}, {});
+      let control: FormControl = <FormControl> form.get('title');
+
+      expect(field.hide).toBeTruthy();
+      expect(field.formControl).not.toBeNull();
+      expect(control).toBeNull();
+    });
   });
 
   describe('merge field options', () => {

--- a/src/core/src/services/formly.form.builder.ts
+++ b/src/core/src/services/formly.form.builder.ts
@@ -262,7 +262,7 @@ export class FormlyFormBuilder {
 
     this.addControl(form, name, formControl, field);
     if (field.validation && field.validation.show) {
-      form.get(field.key).markAsTouched();
+      formControl.markAsTouched();
     }
   }
 


### PR DESCRIPTION
… is true

Addresses a null reference introduced by #417 that can occur when `validation.show` is true.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
Attempts to call `markAsTouched` on a null object reference.


**What is the new behavior (if this is a feature change)?**
Calls `markAsTouched` on the existing reference.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/533)
<!-- Reviewable:end -->
