### PR TITLE
feat(field): remove deprecated `valid` prop.

### DIFF
--- a/src/core/src/templates/field.ts
+++ b/src/core/src/templates/field.ts
@@ -14,15 +14,6 @@ export abstract class Field {
 
   get to(): FormlyTemplateOptions { return this.field.templateOptions; }
 
-  /**
-   * @deprecated Use `showError` instead.
-   **/
-  get valid(): boolean {
-    console.warn(`${this.constructor.name}: 'valid' is deprecated. Use 'showError' instead.`);
-
-    return this.showError;
-  }
-
   get showError(): boolean { return this.options.showError(this); }
 
   get id(): string { return this.field.id; }


### PR DESCRIPTION
BREAKING CHANGE: `Field::valid` is no longer available, use `showError` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formly-js/ng-formly/537)
<!-- Reviewable:end -->
